### PR TITLE
Setup redis session driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# should be replaced by value from `php artisan key:generate --show`
+APP_KEY=1234
+APP_DEBUG=true

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ All services managed using docker compose
 ## Plan
 
 From my limited research, it seems that there are a couple of steps required to achieve this goal:
-- use the same backend for session driver in each frameworks, here we use Redis -> trivial
+- use the same backend for session driver in each frameworks, here we use Redis -> done
 - use the same Redis key format -> should be configurable, need to make sure
-- use the same serialization key -> require considerable configuration
+  - laravel has `database.redis.prefix` config var which could be changed to edit its Redis prefix key which would be used to store session key
 - use the same cookie variable name -> should be configurable, need to make sure
+  - laravel has `session.cookie` config var which could be changed to edit its cookie variable name
+- use the same serialization method -> require considerable configuration
 
 ## Alternative
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ PHP by default provided a native [Session handling mechanism](https://www.php.ne
 
 All services managed using docker compose
 
-# Setup
+## Setup
 - `docker compose up`
 - website could be accessed at http://localhost:8000
+
+## Plan
+
+From my limited research, it seems that there are a couple of steps required to achieve this goal:
+- use the same backend for session driver in each frameworks, here we use Redis -> trivial
+- use the same Redis key format -> should be configurable, need to make sure
+- use the same serialization key -> require considerable configuration
+- use the same cookie variable name -> should be configurable, need to make sure
+
+## Alternative
+
+If its later revealed that the above steps is impossible or prohibitively difficult, than here I list a couple alternative solutions:
+- use OAuth 2.0 or OpenID Connection to achieve synced user session

--- a/codeigniter/Dockerfile
+++ b/codeigniter/Dockerfile
@@ -2,3 +2,7 @@ FROM php:7.2-apache
 
 RUN a2enmod rewrite
 
+# Install PHP extensions
+# ref: https://stackoverflow.com/a/63579640/2496217
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+RUN install-php-extensions redis

--- a/codeigniter/application/config/config.php
+++ b/codeigniter/application/config/config.php
@@ -377,10 +377,15 @@ $config['encryption_key'] = '';
 | except for 'cookie_prefix' and 'cookie_httponly', which are ignored here.
 |
 */
-$config['sess_driver'] = 'files';
+// redis driver
+$config['sess_driver'] = 'redis';
+$config['sess_save_path'] = 'tcp://redis:6379'; // ref: https://codeigniter.com/userguide3/libraries/sessions.html#redis-driver
+
+// file driver
+//$config['sess_driver'] = 'files';
+//$config['sess_save_path'] = sys_get_temp_dir(); // ref: https://stackoverflow.com/a/33898705
 $config['sess_cookie_name'] = 'ci_session';
 $config['sess_expiration'] = 7200;
-$config['sess_save_path'] = sys_get_temp_dir(); // ref: https://stackoverflow.com/a/33898705
 $config['sess_match_ip'] = FALSE;
 $config['sess_time_to_update'] = 300;
 $config['sess_regenerate_destroy'] = FALSE;

--- a/codeigniter/application/controllers/Sesi.php
+++ b/codeigniter/application/controllers/Sesi.php
@@ -16,9 +16,11 @@ class Sesi extends CI_Controller {
 	{
 		if (!$this->session->random_value)
 			$this->session->random_value = random_string('alnum', 16);
+        $session_id = $this->session->session_id;
 
 		echo "Random value in session: " . $this->session->random_value;
 		echo "<br/>Date Time: " . date('Y-m-d H:i:s');
+		echo "<br/>Session ID: $session_id";
 		echo "<br/><a href='" . site_url('sesi/reset') . "' target='_blank'>Reset value</a>";
 	}
 

--- a/codeigniter/application/controllers/Sesi.php
+++ b/codeigniter/application/controllers/Sesi.php
@@ -16,12 +16,17 @@ class Sesi extends CI_Controller {
 	{
 		if (!$this->session->random_value)
 			$this->session->random_value = random_string('alnum', 16);
-        $session_id = $this->session->session_id;
+        $output = json_encode([
+            'random_value' => $this->session->random_value,
+		    'dat_time' => date('Y-m-d H:i:s'),
+		    'session_id' => $this->session->session_id,
+		    'reset_url' => site_url('sesi/reset'),
+            'session_data' => $this->session,
+        ]);
 
-		echo "Random value in session: " . $this->session->random_value;
-		echo "<br/>Date Time: " . date('Y-m-d H:i:s');
-		echo "<br/>Session ID: $session_id";
-		echo "<br/><a href='" . site_url('sesi/reset') . "' target='_blank'>Reset value</a>";
+        return $this->output
+            ->set_content_type('application/json')
+            ->set_output($output);
 	}
 
 	public function reset()

--- a/codeigniter/index.php
+++ b/codeigniter/index.php
@@ -89,6 +89,8 @@ switch (ENVIRONMENT)
 		exit(1); // EXIT_ERROR
 }
 
+ini_set('session.serialize_handler', 'php_serialize');
+
 /*
  *---------------------------------------------------------------
  * SYSTEM DIRECTORY NAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,6 @@ services:
     volumes:
       - ./laravel:/app
     #command: php artisan serve --host 0.0.0.0 --port 8000
+
+  redis:
+    image: redis:alpine

--- a/laravel/Dockerfile
+++ b/laravel/Dockerfile
@@ -6,12 +6,12 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 # ref: https://stackoverflow.com/a/63579640/2496217
 #COPY --from=registry.digitalservice.id/proxyjds/library/mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
-#COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+# Install PHP extensions
+RUN install-php-extensions redis
 
 WORKDIR /app
 
-# Install PHP extensions
-#RUN install-php-extensions ldap
 
 # ini gak bisa dibuat copy composer aja karena di composer install ada tahap eksekusi artisan. kalau di copy hanya file composer, file artisannnya tidak ada dan jadinya composer installnya gagal
 COPY .  /app

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_DRIVER', 'file'),
+    'default' => env('CACHE_DRIVER', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -105,6 +105,7 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
+    //'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
+    'prefix' => 'ci_session',
 
 ];

--- a/laravel/config/database.php
+++ b/laravel/config/database.php
@@ -125,7 +125,8 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
+            //'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
+            'prefix' => '',
         ],
 
         'default' => [

--- a/laravel/config/database.php
+++ b/laravel/config/database.php
@@ -129,7 +129,7 @@ return [
         ],
 
         'default' => [
-            'url' => env('REDIS_URL'),
+            'url' => env('REDIS_URL', 'tcp://redis:6379'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'username' => env('REDIS_USERNAME'),
             'password' => env('REDIS_PASSWORD'),

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -18,7 +18,7 @@ return [
     |
     */
 
-    'driver' => env('SESSION_DRIVER', 'file'),
+    'driver' => env('SESSION_DRIVER', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -72,7 +72,7 @@ return [
     |
     */
 
-    'connection' => env('SESSION_CONNECTION'),
+    'connection' => env('SESSION_CONNECTION', 'default'),
 
     /*
     |--------------------------------------------------------------------------

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -126,10 +126,11 @@ return [
     |
     */
 
-    'cookie' => env(
-        'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
-    ),
+    'cookie' => 'ci_session',
+    //'cookie' => env(
+        //'SESSION_COOKIE',
+        //Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+    //),
 
     /*
     |--------------------------------------------------------------------------

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -199,4 +199,8 @@ return [
 
     'same_site' => 'lax',
 
+    // undocumented settings to change Laravel's Session Storage serialization strategy
+    // ref; https://github.com/laravel/framework/pull/40595
+    'serialization' => 'php',
+
 ];

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -22,5 +22,6 @@ Route::get('/', function () {
         'random_value_in_sesson' => session('random_value'),
         'random_value_by_laravel' => session('random_laravel_value'),
         'session_id' => session()->getId(),
+        'session_data' => session()->all(),
     ]);
 });

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -14,7 +14,13 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', function () {
+    session([
+        'random_laravel_value' => \Illuminate\Support\Str::random(16)
+    ]);
+
     return response()->json([
         'random_value_in_sesson' => session('random_value'),
+        'random_value_by_laravel' => session('random_laravel_value'),
+        'session_id' => session()->getId(),
     ]);
 });


### PR DESCRIPTION
- setup redis container in docker-compose.yml
- configure redis as session driver in both Laravel & Codeigniter

## Problem in Codeigniter
- CI version used by SIKD (3.1.8) has some bug regarding deprecated method in Predis. It should be upgraded to latest version. 
  - reference: https://stackoverflow.com/a/71674977
  - Screenshot: 
![image](https://user-images.githubusercontent.com/2698551/186075666-c7f85a05-80f6-434e-8b3c-ed2b0d6e4ca6.png)

## Possible problem regarding Laravel-Codeigniter shared session mechanism:
- both have different key format
- both have different serialization strategy (laravel use JSON, while CI use some other method. maybe using PHP's [serialize()](https://www.php.net/manual/en/function.serialize.php) or [session_decode()](https://www.php.net/manual/en/function.session-decode.php) method)?
<img width="715" alt="Screen Shot 2022-08-23 at 12 20 20" src="https://user-images.githubusercontent.com/2698551/186076165-f68dec8d-503d-425d-8983-5f3e06e3a2e8.png">

possible solution: use a custom third party session driver to achieve uniform redis session storage mechanism

## chosen solution

change both session serialization settings to use PHP's `serialize()` method

<img width="719" alt="Screen Shot 2022-08-23 at 16 34 39" src="https://user-images.githubusercontent.com/2698551/186125034-fda398e9-d60f-4700-982f-aebaccebf98c.png">

